### PR TITLE
Refactor Request#prepare!

### DIFF
--- a/lib/hurley/client.rb
+++ b/lib/hurley/client.rb
@@ -176,42 +176,56 @@ module Hurley
     end
 
     def prepare!
-      if value = !header[:authorization] && url.basic_auth
-        header[:authorization] = value
-      end
+      set_authorization_header_from_basic_auth! unless header[:authorization]
 
       if body
-        ctype = nil
-        case body
-        when Query
-          ctype, io = body.to_form
-          self.body = io
-        when Hash
-          ctype, io = options.build_form(body)
-          self.body = io
-        end
-        header[:content_type] ||= ctype || DEFAULT_TYPE
+        prepare_body_and_content_type!
       else
         return unless REQUIRED_BODY_VERBS.include?(verb)
       end
 
-      if !header.key?(:content_length) && header[:transfer_encoding] != CHUNKED
-        if body
-          if sizer = SIZE_METHODS.detect { |method| body.respond_to?(method) }
-            header[:content_length] = body.send(sizer).to_i
-          else
-            header[:transfer_encoding] = CHUNKED
-          end
-        else
-          header[:content_length] = 0
-        end
-      end
+      set_content_length_or_chunked! unless content_length_or_chunked_set?
     end
 
     private
 
     def body_receiver
       @body_receiver ||= [nil, BodyReceiver.new]
+    end
+
+    def set_authorization_header_from_basic_auth!
+      header[:authorization] = url.basic_auth if url.basic_auth
+    end
+
+    def prepare_body_and_content_type!
+      case body
+      when Query
+        ctype, io = body.to_form
+        self.body = io
+        header[:content_type] ||= ctype
+      when Hash
+        ctype, io = options.build_form(body)
+        self.body = io
+        header[:content_type] ||= ctype
+      else
+        header[:content_type] ||= DEFAULT_TYPE
+      end
+    end
+
+    def content_length_or_chunked_set?
+      header.key?(:content_length) || header[:transfer_encoding] == CHUNKED
+    end
+
+    def set_content_length_or_chunked!
+      if body
+        if sizer = SIZE_METHODS.detect { |method| body.respond_to?(method) }
+          header[:content_length] = body.send(sizer).to_i
+        else
+          header[:transfer_encoding] = CHUNKED
+        end
+      else
+        header[:content_length] = 0
+      end
     end
 
     DEFAULT_TYPE = "application/octet-stream".freeze

--- a/lib/hurley/client.rb
+++ b/lib/hurley/client.rb
@@ -194,7 +194,7 @@ module Hurley
     end
 
     def set_authorization_header_from_basic_auth!
-      header[:authorization] = url.basic_auth if url.basic_auth
+      header[:authorization] = url.basic_auth if url.basic_auth?
     end
 
     def prepare_body_and_content_type!

--- a/lib/hurley/url.rb
+++ b/lib/hurley/url.rb
@@ -155,6 +155,10 @@ module Hurley
       "Basic #{Base64.encode64(userinfo).rstrip}"
     end
 
+    def basic_auth?
+      @user ? true : false
+    end
+
     def query_class
       @query_class ||= Query.default
     end

--- a/test/url_test.rb
+++ b/test/url_test.rb
@@ -408,10 +408,8 @@ module Hurley
     end
 
     def test_basic_auth?
-      url_with_user = Url.parse("https://a@example.com")
-      assert_equal url_with_user.basic_auth?, true
-      url_without_user = Url.parse("https://example.com")
-      assert_equal url_without_user.basic_auth?, false
+      assert Url.parse("https://a@example.com").basic_auth?
+      assert !Url.parse("https://example.com").basic_auth?
     end
 
     def test_join_url_with_auth_url

--- a/test/url_test.rb
+++ b/test/url_test.rb
@@ -407,6 +407,13 @@ module Hurley
       assert_equal "Basic #{Base64.encode64("a b").rstrip}", u.basic_auth
     end
 
+    def test_basic_auth?
+      url_with_user = Url.parse("https://a@example.com")
+      assert_equal url_with_user.basic_auth?, true
+      url_without_user = Url.parse("https://example.com")
+      assert_equal url_without_user.basic_auth?, false
+    end
+
     def test_join_url_with_auth_url
       u = Url.join("http://c.com/path", "http://a:b@c.com")
       assert_equal "a", u.user


### PR DESCRIPTION
I had trouble reading Request#prepare! so I extracted some methods.

I'm not really happy with prepare_body_and_content_type! - perhaps body.to_form should be split into two methods, one of which returns the default content type and one of which returns the body?