### PR TITLE
Fix minitest

### DIFF
--- a/hurley.gemspec
+++ b/hurley.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.0"
   spec.add_development_dependency "minitest", "~> 5.5.0"
   spec.add_development_dependency "sinatra", "~> 1.4.5"
+  spec.add_development_dependency "rake", "~> 10.4.2"
   spec.authors = ["Rick Olson"]
   spec.description = %q{Simple wrapper for the GitHub API}
   spec.email = ["technoweenie@gmail.com"]

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -2,7 +2,9 @@ require "minitest/autorun"
 require File.expand_path("../../lib/hurley", __FILE__)
 Hurley.require_lib "test"
 
+puts $LOAD_PATH
+
 module Hurley
-  class TestCase < MiniTest::Test
-  end
+  base_class = defined?(MiniTest::Test) ? MiniTest::Test : MiniTest::Unit::TestCase
+  TestCase = Class.new(base_class)
 end


### PR DESCRIPTION
Trying to fix this in travis builds: `uninitialized constant MiniTest::Test (NameError)`.  Odd that it happens only on ruby 1.9.2, despite using the same minitest gem.  It's apparently falling back to stdlib.