### PR TITLE
fix double sign when parsing query. Fixes #11

### DIFF
--- a/lib/hurley/query.rb
+++ b/lib/hurley/query.rb
@@ -41,7 +41,7 @@ module Hurley
     end
 
     def parse_query(raw_query)
-      raw_query.to_s.split(AMP).each do |pair|
+      raw_query.to_s.split(AMP).reject {|pair| pair.empty? }.each do |pair|
         escaped_key, escaped_value = pair.split(EQ, 2)
         key = CGI.unescape(escaped_key)
         value = escaped_value ? CGI.unescape(escaped_value) : nil

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -185,5 +185,15 @@ module Hurley
       expected.gsub! /\[|\]/, "[" => "%5B", "]" => "%5D"
       assert_equal expected, actual
     end
+
+    def test_parse_double_equal_sign_in_nested_query
+      q = Query::Nested.parse("a[]=1&b[]=2&&c[]=3")
+      assert_equal %w(a b c), q.keys
+    end
+
+    def test_parse_double_equal_sign_in_flat_query
+      q = Query::Flat.parse("a[]=1&b[]=2&&c[]=3")
+      assert_equal %w(a[] b[] c[]), q.keys
+    end
   end
 end


### PR DESCRIPTION
Fix double sign issue, which described here -  #11 