### PR TITLE
add desc about addressable for script/test

### DIFF
--- a/script/test
+++ b/script/test
@@ -17,6 +17,8 @@
 #
 #   # Run against multiple rbenv versions
 #   $ RBENV_VERSIONS="1.9.3-p194 ree-1.8.7-2012.02" script/test
+#   # Run tests with Addressable::URI
+#   $ HURLEY_ADDRESSABLE=1 script/test
 set -e
 
 port=3999


### PR DESCRIPTION
In test/helper.rb exists feature
```ruby
if ENV["HURLEY_ADDRESSABLE"]
  require "addressable/uri"
end
```
So, add description for it.
*Notes:
May be it will be nice to concise it from ```HURLEY_ADDRESSABLE``` to ```ADDRESSABLE```?*
