### PR TITLE
[Fixes #16] Basic Auth Base64 encoding adds \n

### DIFF
--- a/contributors.yaml
+++ b/contributors.yaml
@@ -6,3 +6,4 @@
 Rick Olson: technoweenie@gmail.com
 Wynn Netherland:
 Ben Maraney:
+Kevin Kirsche: kev.kirsche@gmail.com

--- a/lib/hurley/url.rb
+++ b/lib/hurley/url.rb
@@ -152,7 +152,7 @@ module Hurley
     def basic_auth
       return unless @user
       userinfo = @password ? "#{@user}:#{@password}" : @user
-      "Basic #{Base64.encode64(userinfo).rstrip.gsub(/\n/, '')}"
+      "Basic #{Base64.encode64(userinfo).gsub(/\n/, '')}"
     end
 
     def query_class

--- a/lib/hurley/url.rb
+++ b/lib/hurley/url.rb
@@ -152,7 +152,7 @@ module Hurley
     def basic_auth
       return unless @user
       userinfo = @password ? "#{@user}:#{@password}" : @user
-      "Basic #{Base64.encode64(userinfo).rstrip}"
+      "Basic #{Base64.encode64(userinfo).rstrip.gsub(/\n/, '')}"
     end
 
     def query_class

--- a/test/url_test.rb
+++ b/test/url_test.rb
@@ -405,8 +405,7 @@ module Hurley
                     "QX8og3YT%3Fs.%5D8L3h9)@foo.com")
       assert_equal "a b", u.user
       assert_equal "MxYut8Rj8tQi6=wNf.miTxf>q49?,f@vQX8og3YT?s.]8L3h9)", u.password
-      assert_equal "Basic #{Base64.encode64("a b:MxYut8Rj8tQi6=wNf.miTxf>q49?" \
-                                            ",f@vQX8og3YT?s.]8L3h9)").rstrip.gsub(/\n/, '')}", u.basic_auth
+      assert_equal "Basic YSBiOk14WXV0OFJqOHRRaTY9d05mLm1pVHhmPnE0OT8sZkB2UVg4b2czWVQ/cy5dOEwzaDkp", u.basic_auth
     end
 
     def test_basic_auth_user_without_password

--- a/test/url_test.rb
+++ b/test/url_test.rb
@@ -400,6 +400,15 @@ module Hurley
       assert_equal "Basic #{Base64.encode64("a b:1 + 2").rstrip}", u.basic_auth
     end
 
+    def test_basic_auth_user_with_non_encoded_password
+      u = Url.parse("http://a%20b:MxYut8Rj8tQi6%3DwNf.miTxf%3Eq49%3F%2Cf%40v" \
+                    "QX8og3YT%3Fs.%5D8L3h9)@foo.com")
+      assert_equal "a b", u.user
+      assert_equal "MxYut8Rj8tQi6=wNf.miTxf>q49?,f@vQX8og3YT?s.]8L3h9)", u.password
+      assert_equal "Basic #{Base64.encode64("a b:MxYut8Rj8tQi6=wNf.miTxf>q49?" \
+                                            ",f@vQX8og3YT?s.]8L3h9)").rstrip.gsub(/\n/, '')}", u.basic_auth
+    end
+
     def test_basic_auth_user_without_password
       u = Url.parse("http://a%20b@foo.com")
       assert_equal "a b", u.user


### PR DESCRIPTION
[Fixes #16] Basic Auth Base64 encoding adds `\n` to the body of certain complex password combinations.