### PR TITLE
add the concept of an expiring test stub

### DIFF
--- a/lib/hurley/test.rb
+++ b/lib/hurley/test.rb
@@ -6,42 +6,43 @@ module Hurley
       yield self if block_given?
     end
 
-    def get(url, expires: nil)
-      handle(:get, url, expires: expires, &Proc.new)
+    def get(url, options = nil)
+      handle(:get, url, options, &Proc.new)
     end
 
     alias head get
 
-    def put(url, expires: nil)
-      handle(:put, url, expires: expires, &Proc.new)
+    def put(url, options = nil)
+      handle(:put, url, options, &Proc.new)
     end
 
-    def post(url, expires: nil)
-      handle(:post, url, expires: expires, &Proc.new)
+    def post(url, options = nil)
+      handle(:post, url, options, &Proc.new)
     end
 
-    def patch(url, expires: nil)
-      handle(:patch, url, expires: expires, &Proc.new)
+    def patch(url, options = nil)
+      handle(:patch, url, options, &Proc.new)
     end
 
-    def delete(url, expires: nil)
-      handle(:delete, url, expires: expires, &Proc.new)
+    def delete(url, options = nil)
+      handle(:delete, url, options, &Proc.new)
     end
 
-    def options(url, expires: nil)
-      handle(:options, url, expires: expires, &Proc.new)
+    def options(url, options = nil)
+      handle(:options, url, options, &Proc.new)
     end
 
-    def handle(verb, url, expires: nil)
+    def handle(verb, url, options = nil)
       # treat HEAD responses like GET
       req_verb = verb == :head ? :get : verb
       vu = [req_verb, url]
 
       if existing = @handlers_by_verb_and_url[vu]
-        expires = existing.expires = true
+        existing.expires = true
+        (options ||= {}).update(:expires => true)
       end
 
-      h = Handler.new(Request.new(req_verb, Url.parse(url)), Proc.new, expires: expires)
+      h = Handler.new(Request.new(req_verb, Url.parse(url)), Proc.new, options)
       @handlers_by_verb_and_url[vu] ||= h
       @handlers << h
     end
@@ -69,11 +70,11 @@ module Hurley
         end
       end
 
-      def initialize(request, callback, expires: nil)
+      def initialize(request, callback, options = nil)
         @run = false
         @request = request
         @callback = callback
-        @expires = expires ? true : false
+        @expires = (options && options[:expires]) ? true : false
         @path_regex = %r{\A#{@request.url.path}(/|\z)}
       end
 

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -3,7 +3,7 @@ require File.expand_path("../helper", __FILE__)
 module Hurley
   class ClientTest < TestCase
     def test_integration_verbs
-      verbs = [:head, :get, :put, :post, :delete, :options]
+      verbs = [:get, :put, :post, :delete, :options]
       client = Client.new "https://example.com"
       client.connection = Test.new do |t|
         verbs.each do |verb|
@@ -25,6 +25,25 @@ module Hurley
       if errors.any?
         fail "\n" + errors.join("\n")
       end
+    end
+
+    def test_head_verb
+      client = Client.new "https://example.com"
+      client.connection = Test.new do |t|
+        t.head("/a") do |req|
+          [200, {"Content-Length" => "4"}, "head"]
+        end
+      end
+
+      res = client.head("/a")
+      assert_equal 200, res.status_code
+      assert_equal "4", res.header[:content_length]
+      assert_nil res.body
+
+      res = client.get("/a")
+      assert_equal 200, res.status_code
+      assert_equal "4", res.header[:content_length]
+      assert_equal "head", res.body
     end
 
     def test_integration_before_callback

--- a/test/test_test.rb
+++ b/test/test_test.rb
@@ -8,9 +8,24 @@ module Hurley
         stub.get "/a/verboten" do |req|
           [403, {}, ""]
         end
-        stub.get("/a") do |req|
+
+        stub.get("/a", expires: false) do |req|
           output = %w(fee fi fo fum)
-          [200, {}, output.join("\n")]
+          [200, {"Content-Length" => "13"}, output.join("\n")]
+        end
+
+        # forces the /a stub above to expire
+        stub.get("/a") do |req|
+          [200, {"Content-Length" => "4"}, "last"]
+        end
+
+        stub.get("/expires", expires: true) do |req|
+          [200, {}, "last"]
+        end
+
+        # different verb, does not expire
+        stub.post("/expires") do |req|
+          [200, {}, "ok"]
         end
       end
 
@@ -33,6 +48,51 @@ module Hurley
 
       res = @client.get("/b")
       assert_equal 404, res.status_code
+    end
+
+    def test_get_expiring_stub
+      res = @client.get("/a")
+      assert_equal 200, res.status_code
+      assert_equal "fee\nfi\nfo\nfum", res.body
+
+      res = @client.get("/a")
+      assert_equal 200, res.status_code
+      assert_equal "last", res.body
+
+      res = @client.get("/a")
+      assert_equal 404, res.status_code
+    end
+
+    def test_head_expiring_stub
+      res = @client.head("/a")
+      assert_equal 200, res.status_code
+      assert_equal "13", res.header[:content_length]
+
+      res = @client.get("/a")
+      assert_equal 200, res.status_code
+      assert_equal "4", res.header[:content_length]
+
+      res = @client.get("/a")
+      assert_equal 404, res.status_code
+    end
+
+    def test_matches_explicitly_expiring_stub
+      res = @client.get("/expires")
+      assert_equal 200, res.status_code
+      assert_equal "last", res.body
+
+      res = @client.get("/expires")
+      assert_equal 404, res.status_code
+    end
+
+    def test_matches_expiring_url_with_different_verb
+      res = @client.post("/expires")
+      assert_equal 200, res.status_code
+      assert_equal "ok", res.body
+
+      res = @client.post("/expires")
+      assert_equal 200, res.status_code
+      assert_equal "ok", res.body
     end
   end
 end

--- a/test/test_test.rb
+++ b/test/test_test.rb
@@ -9,7 +9,7 @@ module Hurley
           [403, {}, ""]
         end
 
-        stub.get("/a", expires: false) do |req|
+        stub.get("/a", :expires => false) do |req|
           output = %w(fee fi fo fum)
           [200, {"Content-Length" => "13"}, output.join("\n")]
         end
@@ -19,7 +19,7 @@ module Hurley
           [200, {"Content-Length" => "4"}, "last"]
         end
 
-        stub.get("/expires", expires: true) do |req|
+        stub.get("/expires", :expires => true) do |req|
           [200, {}, "last"]
         end
 


### PR DESCRIPTION
Fixes #18. You can now define multiple stubs for a URL in your tests. Multiple calls to the stub will call each URL in succession. Any stubs defined just once never expire, unless specifically configured to do so.

```ruby
client = Hurley::Client.new "https://example.com"
client.connection = Hurley::Test.new do |stubs|
  # this stub will return 1, 2, and then 3
  stubs.get("/next") do |req|
    [200, {}, "1"]
  end
  stubs.get("/next") do |req|
    [200, {}, "2"]
  end
  stubs.get("/next") do |req|
    [200, {}, "3"]
  end

  # this stub always returns status 405
  stubs.post("/next") do |req|
    [405, {}, "Method not Allowed"]
  end

  # this stub only works once
  stubs.delete("/a", expires: true) do |req|
    [200, {}, "ok"]
  end
end
```

This doesn't work on ruby < 2.0 yet.