### PR TITLE
Fix #33 - Propagate non-default on_body receivers through redirects

### DIFF
--- a/lib/hurley/client.rb
+++ b/lib/hurley/client.rb
@@ -269,7 +269,10 @@ module Hurley
       @location ||= begin
         return unless loc = @header[:location]
         verb = STATUS_FORCE_GET.include?(status_code) ? :get : request.verb
-        Request.new(verb, request.url.join(Url.parse(loc)), request.header, request.body, request.options, request.ssl_options)
+        statuses, receiver = request.send(:body_receiver)
+        new_request = Request.new(verb, request.url.join(Url.parse(loc)), request.header, request.body, request.options, request.ssl_options)
+        new_request.on_body(*statuses, &receiver) unless receiver.is_a?(Hurley::BodyReceiver)
+        new_request
       end
     end
 


### PR DESCRIPTION
Copies any on_body receivers through automatic redirects. Generally we only want the last body received. In the default case, the BodyReceiver will just get reset each time which is fine. For custom receivers, redirect response bodies can be ignored by filtering on status (e.g. only 200, 201..)

Needs #28 to me merged to work outside tests.
 