### PR TITLE
Add sinatra as development dependency for CI

### DIFF
--- a/hurley.gemspec
+++ b/hurley.gemspec
@@ -9,6 +9,7 @@ contributors = YAML.load(IO.read(File.expand_path("../contributors.yaml", __FILE
 
 Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.0"
+  spec.add_development_dependency "sinatra", "~> 1.4"
   spec.authors = contributors.keys.compact
   spec.description = %q{Hurley provides a common interface for working with different HTTP adapters.}
   spec.email = contributors.values.compact


### PR DESCRIPTION
Used for test suite. Currently, deploying tests out to Travis CI fail as it doesn't have Sinatra to run the tests