### PR TITLE
Don't use a comma after last list item in tasks

### DIFF
--- a/lib/hurley/tasks.rb
+++ b/lib/hurley/tasks.rb
@@ -10,7 +10,7 @@ namespace :hurley do
     Hurley::Live.start_server(
       :port => (ENV["HURLEY_PORT"] || 4000).to_i,
       :ssl_key => ENV["HURLEY_SSL_KEY"],
-      :ssl_file => ENV["HURLEY_SSL_FILE"],
+      :ssl_file => ENV["HURLEY_SSL_FILE"]
     )
   end
 


### PR DESCRIPTION
This should fix issues with JRuby / RBX where the last parenthesis is unexpected due to the comma.

X-Ref: Failing tests in #38