### PR TITLE
Only omit query values if nil

### DIFF
--- a/lib/hurley/query.rb
+++ b/lib/hurley/query.rb
@@ -179,7 +179,7 @@ module Hurley
 
     class Pair < Struct.new(:key, :escaped_key, :value)
       def to_s
-        if value
+        if !value.nil?
           "#{escaped_key}=#{Url.escape_path(value)}"
         else
           escaped_key


### PR DESCRIPTION
Allows values that would otherwise eval as false (false, 0, etc.) to be used as query values.
